### PR TITLE
Reimplemented dirtying, did some cleaning.

### DIFF
--- a/EnumMaskProperty.cs
+++ b/EnumMaskProperty.cs
@@ -1,0 +1,15 @@
+using System;
+using UnityEngine;
+
+[AttributeUsage(AttributeTargets.Field, AllowMultiple = false)]
+public class EnumMaskAttribute : PropertyAttribute
+{
+    public bool alwaysFoldOut = true;
+    public EnumMaskLayout layout = EnumMaskLayout.Vertical;
+}
+
+public enum EnumMaskLayout
+{
+    Vertical,
+    Horizontal
+}


### PR DESCRIPTION
Moved the EnumMaskProperty to it's own file. Replaced the Undo.RecordObject calls with setting the serialized property, as that supports Undo and serializes changes in a much cleaner way. Did some minor code cleanup